### PR TITLE
Trim down the size of the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,13 @@
 #
 
 # Pull base image
-FROM ubuntu:trusty
+FROM python:2.7-slim
 
-
-RUN apt-get update && apt-get install -y git python-pip
-
-#RUN pip install coursera
+#RUN pip install coursera-dl
 ###############################################################################
 # This block will be removed after coursera will be published on PyPi
 
-# RUN git clone https://github.com/coursera-dl/coursera.git
-RUN git clone -b add-setup https://github.com/mshytikov/coursera.git
-WORKDIR /coursera
-RUN python setup.py build sdist && pip install dist/coursera-dl-*.tar.gz
+RUN pip install https://github.com/mshytikov/coursera/archive/add-setup.tar.gz#egg=coursera-dl-0.0.1
 ###############################################################################
 
 VOLUME /downloads


### PR DESCRIPTION
This change pursues two goals: trimming down the image size and speed up the build time.

Here's the outcome:

```
$ docker images */coursera-dl-docker
REPOSITORY                    TAG     IMAGE ID        CREATED              VIRTUAL SIZE
madkinder/coursera-dl-docker  latest  9670094d7362    About a minute ago   210.3 MB
mshytikov/coursera-dl-docker  latest  34a00c2c6c42    8 minutes ago        401.1 MB
```

Both `ubuntu:trusty` and `python:2.7-slim` are official images, so no regression in this regard.

Coursera-related stuff adds just 6.3 MB on top of `python:2.7-slim` (in contrast to 201.8 MB of extra size on top of old `ubuntu:trusty` based build), most of the base layers would be already downloaded for vast majority of docker users. So the build is lightning fast.
